### PR TITLE
bugfix: updated logging to prevent server crash on error

### DIFF
--- a/handlers/events.go
+++ b/handlers/events.go
@@ -1,7 +1,6 @@
 package handlers
 
 import (
-	"log"
 	"log/slog"
 	"net/http"
 	"strings"
@@ -15,8 +14,8 @@ func CreateEventForm(w http.ResponseWriter, r *http.Request) {
 
 	events, err := models.GetAllActiveEvents()
 	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		log.Printf("Error retreiving events %v", err)
+		http.Error(w, "Error retreiving events", http.StatusInternalServerError)
+		slog.Error("error retreiving events", "error", err)
 		return
 	}
 
@@ -33,12 +32,14 @@ func CreateEventForm(w http.ResponseWriter, r *http.Request) {
 func CreateEvent(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		slog.Error("Method not allowed", "Method", r.Method)
 		return
 	}
 
 	err := r.ParseForm()
 	if err != nil {
 		http.Error(w, "Invalid form data", http.StatusBadRequest)
+		slog.Error("Invalid form data", "error", err)
 		return
 	}
 
@@ -54,17 +55,20 @@ func CreateEvent(w http.ResponseWriter, r *http.Request) {
 	// Validate required fields
 	if name == "" || recipientName == "" || recipientContact == "" {
 		http.Error(w, "Name, recipient name, and recipient contact are required", http.StatusBadRequest)
+		slog.Error("required field left blank in event creation form")
 		return
 	}
 
-	if utils.ValidateEmail(recipientContact); err != nil {
+	if err = utils.ValidateEmail(recipientContact); err != nil {
 		http.Error(w, "Invalid recipient Email", http.StatusBadRequest)
+		slog.Error("Invalid recipient Email", "email", recipientContact)
 		return
 	}
 
 	if coordinatorContact != "" {
-		if utils.ValidateEmail(coordinatorContact); err != nil {
-			http.Error(w, "Invalid recipient Email", http.StatusBadRequest)
+		if err = utils.ValidateEmail(coordinatorContact); err != nil {
+			http.Error(w, "Invalid Coordinator Email", http.StatusBadRequest)
+			slog.Error("Invalid Coordinator Email", "email", coordinatorContact)
 			return
 		}
 
@@ -73,11 +77,13 @@ func CreateEvent(w http.ResponseWriter, r *http.Request) {
 	eventDate, err := time.Parse("2006-01-02", r.FormValue("event_date"))
 	if err != nil {
 		http.Error(w, "Invalid event date format", http.StatusBadRequest)
+		slog.Error("Invalid event date format", "event_date", r.FormValue("event_date"))
 		return
 	}
 
 	if eventDate.Before(time.Now().Truncate(24 * time.Hour)) {
 		http.Error(w, "Event date must be in the future", http.StatusBadRequest)
+		slog.Error("Event date must be in the future", "date", eventDate)
 		return
 	}
 
@@ -103,6 +109,7 @@ func CreateEvent(w http.ResponseWriter, r *http.Request) {
 	err = event.SaveEvent()
 	if err != nil {
 		http.Error(w, "Failed to create event", http.StatusInternalServerError)
+		slog.Error("Failed to create event", "event_name", event.Name)
 		return
 	}
 
@@ -119,6 +126,7 @@ func EventCreatedSuccess(w http.ResponseWriter, r *http.Request) {
 	event, err := models.GetEventBySlug(slug)
 	if err != nil {
 		http.Error(w, "Event not found", http.StatusNotFound)
+		slog.Error("Event not found", "event-slug", slug)
 		return
 	}
 

--- a/handlers/submissions.go
+++ b/handlers/submissions.go
@@ -4,7 +4,7 @@ import (
 	"fmt"
 	"image"
 	"image/jpeg"
-	"log"
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -52,7 +52,7 @@ func SubmissionFormHandler(w http.ResponseWriter, r *http.Request, slug string) 
 	event, err := models.GetEventBySlug(slug)
 	if err != nil {
 		http.Error(w, "Unable to retreive event data", http.StatusInternalServerError)
-		log.Fatal(err)
+		slog.Error("Unable to retreive event data", "error", err)
 		return
 	}
 
@@ -109,10 +109,11 @@ func SubmissionHandler(w http.ResponseWriter, r *http.Request, slug string) {
 	if err != nil {
 		if err == http.ErrMissingFile {
 			http.Error(w, "Image upload is required", http.StatusBadRequest)
+			slog.Error("No image found in submission")
 			return
 		}
 		http.Error(w, "Error processing image", http.StatusInternalServerError)
-		log.Println(err)
+		slog.Error("Error processing image", "error", err)
 		return
 	}
 
@@ -138,7 +139,7 @@ func SubmissionHandler(w http.ResponseWriter, r *http.Request, slug string) {
 
 	if !allowedImageTypes[contentType] {
 		http.Error(w, "Only image files (JPEG, PNG, GIF, WebP) are allowed", http.StatusBadRequest)
-		log.Printf("Invalid file type: %s", contentType)
+		slog.Error("Invalid file type", "content-type", contentType)
 		return
 	}
 
@@ -146,16 +147,16 @@ func SubmissionHandler(w http.ResponseWriter, r *http.Request, slug string) {
 	img, format, err := image.Decode(file)
 	if err != nil {
 		http.Error(w, "Error processing image", http.StatusInternalServerError)
-		log.Printf("Image decode error: %v", err)
+		slog.Error("Image decode error", "error", err)
 		return
 	}
-	log.Printf("Successfully decoded image format: %s", format)
+	slog.Info("Successfully decoded image format", "format", format)
 
 	// Resize if width exceeds limit
 	bounds := img.Bounds()
 	width := bounds.Dx()
 	height := bounds.Dy()
-	log.Printf("Original image dimensions: %dx%d", width, height)
+	slog.Info("Original image dimensions", "width", width, "height", height)
 
 	if width > MaxImageWidth {
 		// Calculate new dimensions maintaining aspect ratio
@@ -166,7 +167,7 @@ func SubmissionHandler(w http.ResponseWriter, r *http.Request, slug string) {
 		resized := image.NewRGBA(image.Rect(0, 0, newWidth, newHeight))
 		draw.CatmullRom.Scale(resized, resized.Bounds(), img, bounds, draw.Over, nil)
 		img = resized
-		log.Printf("Resized image from %dx%d to %dx%d", width, height, newWidth, newHeight)
+		slog.Info("Resized image to ", "newWidth", newWidth, "newHeight", newHeight)
 	}
 
 	var filename string
@@ -185,7 +186,7 @@ func SubmissionHandler(w http.ResponseWriter, r *http.Request, slug string) {
 	dst, err := os.Create(filePath)
 	if err != nil {
 		http.Error(w, "Error saving file", http.StatusInternalServerError)
-		log.Printf("File save error: %v", err)
+		slog.Error("File save error", "error", err)
 		return
 	}
 
@@ -195,14 +196,14 @@ func SubmissionHandler(w http.ResponseWriter, r *http.Request, slug string) {
 	err = jpeg.Encode(dst, img, &jpeg.Options{Quality: 85})
 	if err != nil {
 		http.Error(w, "Error saving file", http.StatusInternalServerError)
-		log.Printf("JPEG encode error: %v", err)
+		slog.Error("JPEG encode error", "error", err)
 		return
 	}
 
 	event, err := models.GetEventBySlug(slug)
 	if err != nil {
 		http.Error(w, "Unable to retreive event data", http.StatusInternalServerError)
-		log.Fatal(err)
+		slog.Error("Unable to retreive event data", "error", err)
 		return
 	}
 
@@ -210,7 +211,7 @@ func SubmissionHandler(w http.ResponseWriter, r *http.Request, slug string) {
 	err = saveSubmission(event.ID, name, message, filename)
 	if err != nil {
 		http.Error(w, "Error saving submission to database", http.StatusInternalServerError)
-		log.Printf("Database save error: %v", err)
+		slog.Error("Database save error", "error", err)
 		return
 	}
 
@@ -224,18 +225,18 @@ func SubmissionHandler(w http.ResponseWriter, r *http.Request, slug string) {
 
 	// Get saved file size for verification
 	fileInfo, _ := dst.Stat()
-	log.Printf("Successfully saved processed image: %s (size: %.2f KB)", filename, float64(fileInfo.Size())/1024)
+	slog.Info("Successfully saved processed image: %s (size: %.2f KB)", filename, float64(fileInfo.Size())/1024)
 
 	renderTemplate(w, "./templates/success.html", data)
 
-	log.Printf("Received submission - Name: %s", name)
+	slog.Info("Received submission", "name", name)
 }
 
 func ViewSubmissionsByEvent(w http.ResponseWriter, r *http.Request, slug string) {
 	submissions, err := models.GetSubmissionsByEventSlug(slug)
 	if err != nil {
 		http.Error(w, "Error retrieving event submissions", http.StatusInternalServerError)
-		log.Printf("%v", err)
+		slog.Error("Error retreiving submissions", "error", err)
 		return
 	}
 


### PR DESCRIPTION
## Description
The `submissions.go` and `events.go` files had improper logging that, under certain errors, triggered `os.Exit(1)` and crashes the entire program.

Fixes # (issue)

1.  Replaced all identified `log.Fatal()` calls with `slog.Error` to avoid complete crash of the program.
2. Minor updates to other logs by updating all to `slog.*` instead of `log.*` for consistency in the codebase.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
N/A - To implement more unit tests in the future. Since these fixes were just log changes, I ran the application to verify they worked properly.

## Checklist:
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes